### PR TITLE
Add project support to todoist_create_task and new todoist_get_projects tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,8 +35,8 @@ npm install -g @abhiz123/todoist-mcp-server
 ### todoist_create_task
 Create new tasks with various attributes:
 * Required: content (task title)
-* Optional: description, due date, priority level (1-4)
-* Example: "Create task 'Team Meeting' with description 'Weekly sync' due tomorrow"
+* Optional: description, due date, priority level (1-4), project
+* Example: "Create task 'Team Meeting' with description 'Weekly sync' due tomorrow in project 'Work'"
 
 ### todoist_get_tasks
 Retrieve and filter tasks:
@@ -62,6 +62,12 @@ Remove tasks using natural language search:
 * Find and delete tasks by name
 * Confirmation messages
 * Example: "Delete the PR review task"
+
+### todoist_get_projects
+Get a list of all available projects:
+* Shows project names, IDs, and colors
+* Useful for finding project names to use in task creation
+* Example: "Show all my projects"
 
 ## Setup
 
@@ -95,6 +101,8 @@ Add to your `claude_desktop_config.json`:
 "Create task 'Team Meeting'"
 "Add task 'Review PR' due tomorrow at 2pm"
 "Create high priority task 'Fix bug' with description 'Critical performance issue'"
+"Create task 'Design review' in project 'Work'"
+"Add task 'Buy groceries' in project 'Personal' due today"
 ```
 
 ### Getting Tasks
@@ -122,6 +130,13 @@ Add to your `claude_desktop_config.json`:
 ```
 "Delete the PR review task"
 "Remove meeting prep task"
+```
+
+### Getting Projects
+```
+"Show all my projects"
+"List available projects"
+"Get project list"
 ```
 
 ## Development


### PR DESCRIPTION
Hi!

I needed to create tasks in Todoist with specific project assignments, but found that the current server version doesn't support this functionality. So I decided to add project support and also created a convenient tool for viewing available projects.

### What's added:

**Project support in `todoist_create_task`:**
- New optional `project_id` parameter
- Smart project search by name or ID (no need to remember project IDs!)
- Full backward compatibility - all existing functionality works as before

**New `todoist_get_projects` tool:**
- Shows list of all available projects with names, IDs, and colors
- Helps users find the right project for creating tasks

### Usage examples:

```bash
# Creating tasks in specific projects
"Create task 'Design review' in project 'Work'"
"Add task 'Buy groceries' in project 'Personal' due today"

# Viewing available projects
"Show all my projects"
"List available projects"
```

### Technical details:

- Added `findProject()` function for smart project lookup
- Updated type guards to support the new parameter
- Improved error handling with detailed messages
- Updated documentation with new examples

All changes have been tested and are ready to use. Hope this functionality will be useful for other users too!

Thanks for the great project!